### PR TITLE
Resolve incorrect lng, closes #24

### DIFF
--- a/helpers/LAWRENCE_KS.data.ts
+++ b/helpers/LAWRENCE_KS.data.ts
@@ -201,7 +201,7 @@ export const CAMERAS_LAWRENCE_KS_UNPARSED: CAMERA_LAWRENCE_KS[] = [
         x: -10609519.462921897, 
         y: 4715514.159583933,
         lat: 38.957001,
-        lng: -95.204922
+        lng: -95.306935
     },
     {
         LABEL: 'BOB BILLINGS & KASOLD',


### PR DESCRIPTION
Turns out these were stacked on top of each other.